### PR TITLE
Upgrade node image version to 18

### DIFF
--- a/src/services/web-gateway/Dockerfile
+++ b/src/services/web-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Build ./public
-FROM node:17 AS build-react
+FROM node:18 AS build-react
 WORKDIR /service
 COPY ./services/web-gateway/src/public ./src/public
 COPY ./services/web-gateway/package.json .


### PR DESCRIPTION
Version 17 seems not compatible with the parcel bundler, so we need to upgrade to version 18.